### PR TITLE
Fixed Prototype Pollution in properties

### DIFF
--- a/src/properties-reader.js
+++ b/src/properties-reader.js
@@ -205,7 +205,9 @@ PropertiesReader.prototype.set = function (key, value) {
 
    var expanded = key.split('.');
    var source = this._propertiesExpanded;
-
+   if (key.includes('__proto__') || key.includes('prototype') || key.includes('constructor')) {
+      return this;
+   }
    while (expanded.length > 1) {
       var step = expanded.shift();
       if (expanded.length >= 1 && typeof source[step] === 'string') {


### PR DESCRIPTION
### 📊 Metadata *
Fixed ```Prototype Pollution``` in ```properties```

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-properties-reader

### ⚙️ Description *
```properties-reader``` is vulnerable to ```Prototype Pollution```.
Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as ```_proto_```, ```constructor``` and ```prototype```. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *
The bug is fixed by validating the input ```src``` to check for prototypes. It is implemented by a simple validation to check for prototype keywords ```(__proto__, constructor and prototype)```, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *
```javascript
// poc.js
var propertiesReader = require('properties-reader');
console.log("Before : " + {}.polluted)
console.log("Before : " + {}.polluted1)
var properties = propertiesReader('./payload.ini');
properties.set("__proto__.polluted1", "Yes! Its Polluted1");
console.log("After : " + {}.polluted)
console.log("After : " + {}.polluted1)

//payload.ini
[__proto__]
polluted = "Yes! Its Polluted"
```
```
npm i properties-reader # Install affected module
node poc.js #  Run the PoC
```
![propertiespoc](https://user-images.githubusercontent.com/29670330/102102278-9e0f2d80-3e51-11eb-937f-7c5ea1a66c21.png)
### 🔥 Proof of Fix (PoF) *
After the fix is applied, it returns ```undefined``` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.
![propertiespof](https://user-images.githubusercontent.com/29670330/102102328-ab2c1c80-3e51-11eb-8a0d-70ad88a6175b.png)

### 👍 User Acceptance Testing (UAT)
All ok.
